### PR TITLE
refactor: Use var where appropriate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .ionide/
+.fake
 .vscode/
 bin/
 obj/

--- a/GameOfLifeService.Tests/Core/IteratorTest.cs
+++ b/GameOfLifeService.Tests/Core/IteratorTest.cs
@@ -12,73 +12,73 @@ namespace GameOfLifeService.Tests.Core
         [Fact]
         public void Iterate_InvalidState_Throws()
         {
-            GameOfLifeState state = new GameOfLifeState(5, 5, null);
+            var state = new GameOfLifeState(5, 5, null);
             Assert.Throws<System.ArgumentException>(() => iterator.Iterate(state));
         }
 
         [Fact]
         public void Iterate_TrivialState_ReturnsSame()
         {
-            GameOfLifeState state = new GameOfLifeState(0, 0);
-            GameOfLifeState next = iterator.Iterate(state);
+            var state = new GameOfLifeState(0, 0);
+            var next = iterator.Iterate(state);
             Assert.Equal(state, next);
         }
 
         [Fact]
         public void Iterate_DeadState_ReturnsSame()
         {
-            GameOfLifeState state = new GameOfLifeState(10, 10);
-            GameOfLifeState next = iterator.Iterate(state);
+            var state = new GameOfLifeState(10, 10);
+            var next = iterator.Iterate(state);
             Assert.Equal(state, next);
         }
 
         [Fact]
         public void Iterate_Block_ReturnsSame()
         {
-            GameOfLifeState state = new GameOfLifeState(4, 4, new HashSet<(ushort Row, ushort Col)> {
+            var state = new GameOfLifeState(4, 4, new HashSet<(ushort Row, ushort Col)> {
                 (1, 1), (1, 2), (2, 1), (2, 2)
             });
-            GameOfLifeState next = iterator.Iterate(state);
+            var next = iterator.Iterate(state);
             Assert.Equal(state, next);
         }
 
         [Fact]
         public void Iterate_BeeHive_ReturnsSame()
         {
-            GameOfLifeState state = new GameOfLifeState(5, 6, new HashSet<(ushort Row, ushort Col)> {
+            var state = new GameOfLifeState(5, 6, new HashSet<(ushort Row, ushort Col)> {
                 (1, 2), (1, 3), (2, 1), (2, 4), (3, 2), (3, 3)
             });
-            GameOfLifeState next = iterator.Iterate(state);
+            var next = iterator.Iterate(state);
             Assert.Equal(state, next);
         }
 
         [Fact]
         public void Iterate_Loaf_ReturnsSame()
         {
-            GameOfLifeState state = new GameOfLifeState(6, 6, new HashSet<(ushort Row, ushort Col)> {
+            var state = new GameOfLifeState(6, 6, new HashSet<(ushort Row, ushort Col)> {
                 (1, 2), (1, 3), (2, 1), (2, 4), (3, 2), (3, 4), (4, 3)
             });
-            GameOfLifeState next = iterator.Iterate(state);
+            var next = iterator.Iterate(state);
             Assert.Equal(state, next);
         }
 
         [Fact]
         public void Iterate_Tub_ReturnsSame()
         {
-            GameOfLifeState state = new GameOfLifeState(5, 5, new HashSet<(ushort Row, ushort Col)> {
+            var state = new GameOfLifeState(5, 5, new HashSet<(ushort Row, ushort Col)> {
                 (1, 2), (2, 1), (2, 3), (3, 2)
             });
-            GameOfLifeState next = iterator.Iterate(state);
+            var next = iterator.Iterate(state);
             Assert.Equal(state, next);
         }
 
         [Fact]
         public void Iterate_Blinker_OscillatesWithPeriod2()
         {
-            GameOfLifeState state = new GameOfLifeState(5, 5, new HashSet<(ushort Row, ushort Col)> {
+            var state = new GameOfLifeState(5, 5, new HashSet<(ushort Row, ushort Col)> {
                 (2, 1), (2, 2), (2, 3)
             });
-            GameOfLifeState next = iterator.Iterate(state);
+            var next = iterator.Iterate(state);
             Assert.NotEqual(state, next);
 
             next = iterator.Iterate(next);
@@ -88,7 +88,7 @@ namespace GameOfLifeService.Tests.Core
         [Fact]
         public void Iterate_Pentadecathalon_OscillatesWithPeriod15()
         {
-            GameOfLifeState state = new GameOfLifeState(11, 18, new HashSet<(ushort Row, ushort Col)> {
+            var state = new GameOfLifeState(11, 18, new HashSet<(ushort Row, ushort Col)> {
                 (4, 5),
                 (5, 5),
                 (6, 4), (6, 6),
@@ -101,7 +101,7 @@ namespace GameOfLifeService.Tests.Core
                 (13, 5)
             });
 
-            GameOfLifeState next = iterator.Iterate(state);
+            var next = iterator.Iterate(state);
 
             int p = 1;
             while (!state.Equals(next))
@@ -116,10 +116,10 @@ namespace GameOfLifeService.Tests.Core
         [Fact]
         public void Iterate_Glider_LoopsAroundToStart()
         {
-            GameOfLifeState state = new GameOfLifeState(100, 100, new HashSet<(ushort Row, ushort Col)> {
+            var state = new GameOfLifeState(100, 100, new HashSet<(ushort Row, ushort Col)> {
                 (1, 2), (2, 3), (3, 1), (3, 2), (3, 3)
             });
-            GameOfLifeState next = iterator.Iterate(state);
+            var next = iterator.Iterate(state);
 
             int p = 1;
             while (!state.Equals(next))

--- a/GameOfLifeService.Tests/Core/ValidatorTest.cs
+++ b/GameOfLifeService.Tests/Core/ValidatorTest.cs
@@ -12,7 +12,7 @@ namespace GameOfLifeService.Tests.Core
         [Fact]
         public void Validate_ValidState_ReturnsEmptySet()
         {
-            GameOfLifeState state = new GameOfLifeState(5, 5);
+            var state = new GameOfLifeState(5, 5);
             Assert.Empty(validator.Validate(state));
 
             state = new GameOfLifeState(5, 5, new HashSet<(ushort Row, ushort Col)> { (1, 1), (1, 2) });
@@ -22,7 +22,7 @@ namespace GameOfLifeService.Tests.Core
         [Fact]
         public void Validate_OutOfBounds_ReturnsErrorsForEachDimension()
         {
-            GameOfLifeState state = new GameOfLifeState(5, 5, new HashSet<(ushort Row, ushort Col)> { (1, 5) });
+            var state = new GameOfLifeState(5, 5, new HashSet<(ushort Row, ushort Col)> { (1, 5) });
             Assert.Equal(1, validator.Validate(state).Count);
 
             state = new GameOfLifeState(5, 5, new HashSet<(ushort Row, ushort Col)> { (5, 1) });
@@ -35,7 +35,7 @@ namespace GameOfLifeService.Tests.Core
         [Fact]
         public void Validate_OutOfBounds_ReturnsErrorsForEachOccurrence()
         {
-            GameOfLifeState state = new GameOfLifeState(5, 5, new HashSet<(ushort Row, ushort Col)> {
+            var state = new GameOfLifeState(5, 5, new HashSet<(ushort Row, ushort Col)> {
                 (1, 1),
                 (5, 1), // 1 error
                 (1, 5), // 1 error
@@ -48,7 +48,7 @@ namespace GameOfLifeService.Tests.Core
         [Fact]
         public void Validate_NullLiveCells_ReturnsOneError()
         {
-            GameOfLifeState state = new GameOfLifeState(5, 5, null);
+            var state = new GameOfLifeState(5, 5, null);
             Assert.Equal(1, validator.Validate(state).Count);
         }
     }

--- a/GameOfLifeService/Controllers/GameOfLifeController.cs
+++ b/GameOfLifeService/Controllers/GameOfLifeController.cs
@@ -27,7 +27,7 @@ namespace GameOfLifeService.Controllers
             {
                 return StatusCode(500, $"Width and Height must be < {ushort.MaxValue}");
             }
-            GameOfLifeStateDTO dto = GameOfLifeStateDTO.ToDTO(new GameOfLifeState((ushort)width, (ushort)height));
+            var dto = GameOfLifeStateDTO.ToDTO(new GameOfLifeState((ushort)width, (ushort)height));
             return StatusCode(200, dto);
         }
 
@@ -38,7 +38,7 @@ namespace GameOfLifeService.Controllers
             try
             {
                 GameOfLifeState next = _iterator.Iterate(previous);
-                GameOfLifeStateDTO nextDto = GameOfLifeStateDTO.ToDTO(next);
+                var nextDto = GameOfLifeStateDTO.ToDTO(next);
                 return StatusCode(200, nextDto);
             }
             catch (System.ArgumentException e)

--- a/GameOfLifeService/Core/GameOfLifeState.cs
+++ b/GameOfLifeService/Core/GameOfLifeState.cs
@@ -25,7 +25,7 @@ namespace GameOfLifeService.Core
         public override bool Equals(object obj)
         {
             if (obj == null || GetType() != obj.GetType()) return false;
-            GameOfLifeState other = (GameOfLifeState)obj;
+            var other = (GameOfLifeState)obj;
 
             if (other.Width != this.Width) return false;
             if (other.Height != this.Height) return false;

--- a/GameOfLifeService/Core/Iterator.cs
+++ b/GameOfLifeService/Core/Iterator.cs
@@ -22,18 +22,18 @@ namespace GameOfLifeService.Core
 
             // We only need to check cells that are live or adjacent to an existing live cell.
             // For large, sparse grids, this is a pretty big optimization.
-            ISet<(ushort Row, ushort Col)> potentialSurvivors = new HashSet<(ushort Row, ushort Col)>();
-            foreach ((ushort Row, ushort Col) liveCoords in state.LiveCells)
+            var potentialSurvivors = new HashSet<(ushort Row, ushort Col)>();
+            foreach (var liveCoords in state.LiveCells)
             {
                 potentialSurvivors.Add(liveCoords);
-                foreach ((ushort Row, ushort Col) neighborCoords in GetNeighbors(liveCoords, state))
+                foreach (var neighborCoords in GetNeighbors(liveCoords, state))
                 {
                     potentialSurvivors.Add(neighborCoords);
                 }
             }
 
-            ISet<(ushort Row, ushort Col)> survivingCells = new HashSet<(ushort Row, ushort Col)>();
-            foreach ((ushort Row, ushort Col) coords in potentialSurvivors)
+            var survivingCells = new HashSet<(ushort Row, ushort Col)>();
+            foreach (var coords in potentialSurvivors)
             {
                 if (ShouldSurvive(coords, state))
                 {
@@ -53,8 +53,8 @@ namespace GameOfLifeService.Core
 
         private uint CountNeighbors((ushort Row, ushort Col) coords, GameOfLifeState state)
         {
-            uint neighborCount = 0;
-            foreach ((ushort Row, ushort Col) neighborCoords in GetNeighbors(coords, state))
+            var neighborCount = 0u;
+            foreach (var neighborCoords in GetNeighbors(coords, state))
             {
                 if (state.LiveCells.Contains(neighborCoords))
                 {
@@ -70,7 +70,7 @@ namespace GameOfLifeService.Core
             ushort j = coords.Col;
             ISet<(ushort Row, ushort Col)> neighbors = new HashSet<(ushort Row, ushort Col)>();
 
-            int[] offsets = new int[] { -1, 0, 1 };
+            var offsets = new int[] { -1, 0, 1 };
             foreach (int rowOffset in offsets)
             {
                 foreach (int colOffset in offsets)

--- a/GameOfLifeService/Core/Validator.cs
+++ b/GameOfLifeService/Core/Validator.cs
@@ -6,7 +6,7 @@ namespace GameOfLifeService.Core
     {
         public ISet<string> Validate(GameOfLifeState state)
         {
-            ISet<string> errors = new HashSet<string>();
+            var errors = new HashSet<string>();
             if (state.LiveCells == null)
             {
                 errors.Add(MissingLiveCells());

--- a/GameOfLifeService/DTO/GameOfLifeStateDTO.cs
+++ b/GameOfLifeService/DTO/GameOfLifeStateDTO.cs
@@ -36,7 +36,7 @@ namespace GameOfLifeService.DTO
         {
             if (dto == null) return null;
 
-            ISet<(ushort Row, ushort Col)> liveCells = new HashSet<(ushort Row, ushort Col)>();
+            var liveCells = new HashSet<(ushort Row, ushort Col)>();
             if (dto.LiveCells == null)
             {
                 return new GameOfLifeState(dto.Width, dto.Height);


### PR DESCRIPTION
There does not seem to be a single definitive opinion on where var
should be used in place of an explicit type. I have chosen to use it:

- When the type can be trivially inferred by looking at the
  initialization
- When the type is clunky to write out, and the variable is short-lived

I have chosen not to use var:

- For numeric types where size/sign could cause issues